### PR TITLE
fix: Resend sender + Turnstile error handling

### DIFF
--- a/src/app/(marketing)/contact/actions.ts
+++ b/src/app/(marketing)/contact/actions.ts
@@ -118,7 +118,7 @@ export async function submitContactForm(
     const safeMessage = escapeHtml(message);
 
     const { error } = await resend.emails.send({
-      from: "Portfolio <noreply@yourdomain.com>",
+      from: "Portfolio Contact <onboarding@resend.dev>",
       to: ["ahmadyasser03@outlook.com"],
       replyTo: email,
       subject: `Contact from ${safeName}`,


### PR DESCRIPTION
## Summary
- Fix `from` address: use `onboarding@resend.dev` (Resend sandbox sender) instead of unverified `noreply@yourdomain.com`
- Add try-catch + `res.ok` check to Turnstile verification (graceful failure if Cloudflare is down)
- Capture error context in Resend catch block for debugging

## Test plan
- [ ] Submit contact form on preview deployment
- [ ] Verify email is received at ahmadyasser03@outlook.com

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures contact emails are delivered and makes Turnstile verification more robust. Switches to Resend’s sandbox sender and adds graceful error handling with clearer logs.

- **Bug Fixes**
  - Use onboarding@resend.dev as the from address to avoid unverified domain rejections.
  - Wrap Turnstile verification in try/catch and check res.ok; return false on failures.
  - Include error messages in the Resend catch block for easier debugging.

<sup>Written for commit 7ac75436ae194aad4b2bccda33434995cd8d92ba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

