### PR TITLE
fix: scope open-source stats to external contributions only

### DIFF
--- a/src/components/open-source/stats-overview.tsx
+++ b/src/components/open-source/stats-overview.tsx
@@ -29,17 +29,17 @@ const statItems = [
   },
   {
     key: "totalPRs" as const,
-    label: "Pull Requests",
+    label: "External PRs",
     icon: GitPullRequest,
   },
   {
     key: "totalRepos" as const,
-    label: "Repositories",
+    label: "Contributed Repos",
     icon: FolderGit2,
   },
   {
     key: "totalStars" as const,
-    label: "Stars",
+    label: "Stars Earned",
     icon: Star,
   },
 ];

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -393,12 +393,6 @@ export async function getOpenSourceData(): Promise<OpenSourcePageData> {
     ? transformContributions(calendar.weeks)
     : [];
 
-  const totalStars =
-    contrib?.user.repositories.nodes.reduce(
-      (sum, r) => sum + r.stargazerCount,
-      0
-    ) ?? 0;
-
   // Extract repos — only forked repos (external contributions)
   // Use the parent repo's data (stars, forks, url) so the correct counts display
   const reposData =
@@ -417,6 +411,9 @@ export async function getOpenSourceData(): Promise<OpenSourcePageData> {
       isFork: r.isFork,
     }))
     .slice(0, 12);
+
+  // Stars scoped to contributed (forked) repos only
+  const totalStars = repos.reduce((sum, r) => sum + r.stargazerCount, 0);
 
   // Extract PRs
   const prsData =
@@ -474,8 +471,7 @@ export async function getOpenSourceData(): Promise<OpenSourcePageData> {
     totalContributions: calendar?.totalContributions ?? 0,
     totalCommits: contribCollection?.totalCommitContributions ?? 0,
     totalPRs: prsData?.search.issueCount ?? pullRequests.length,
-    totalRepos:
-      contrib?.user.repositories.totalCount ?? repos.length,
+    totalRepos: repos.length,
     totalStars,
   };
 


### PR DESCRIPTION
## Summary
- **totalRepos** now counts only forked (contributed) repos, not all owned repos
- **totalStars** now sums stars from parent repos of forks only
- Updated stat labels to clarify scope: "External PRs", "Contributed Repos", "Stars Earned"
- Contributions & Commits still reflect full GitHub activity (API limitation — calendar can't be filtered by repo ownership)

## Test plan
- [ ] Verify stats cards show correct external-only numbers
- [ ] Verify "Contributed Repos" count matches the number of repo cards displayed
- [ ] Verify "Stars Earned" reflects parent repo stars, not fork stars

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes open-source stats to external contributions only and shows parent (upstream) repo data for forks, so counts and repo cards reflect real impact. Updates labels for clarity.

- **Bug Fixes**
  - totalRepos now counts only forked (contributed) repos; matches the displayed repo cards.
  - totalStars now sums stars from parent repos of forks; repo cards use parent name, URL, language, stars, and forks.
  - Renamed labels: "External PRs", "Contributed Repos", and "Stars Earned".

<sup>Written for commit 925ca9387466f70142683029a4001bf904ba6f75. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

