### PR TITLE
fix: fetch all open+merged PRs and remove Stars Earned card

### DIFF
--- a/src/components/open-source/stats-overview.tsx
+++ b/src/components/open-source/stats-overview.tsx
@@ -7,7 +7,6 @@ import {
   GitCommit,
   GitPullRequest,
   FolderGit2,
-  Star,
   Activity,
 } from "lucide-react";
 import type { GitHubStats } from "@/lib/data/github-types";
@@ -37,17 +36,12 @@ const statItems = [
     label: "Contributed Repos",
     icon: FolderGit2,
   },
-  {
-    key: "totalStars" as const,
-    label: "Stars Earned",
-    icon: Star,
-  },
 ];
 
 export function StatsOverview({ stats }: StatsOverviewProps) {
   return (
     <motion.div
-      className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-4"
+      className="grid grid-cols-2 sm:grid-cols-4 gap-4"
       initial="hidden"
       whileInView="visible"
       viewport={{ once: true, margin: "-50px" }}

--- a/src/lib/data/github-types.ts
+++ b/src/lib/data/github-types.ts
@@ -40,7 +40,6 @@ export interface GitHubStats {
   totalCommits: number;
   totalPRs: number;
   totalRepos: number;
-  totalStars: number;
 }
 
 export interface MonthlyActivity {


### PR DESCRIPTION
## Summary
- Split PRs query into two separate searches (`is:merged` + `is:open`, 100 each) to capture all external PRs — previously `first: 20` missed older PRs like saltstack/salt, cal.com, etc.
- Remove "Stars Earned" stat card entirely
- Grid now 4 columns for remaining stat cards

## Test plan
- [ ] saltstack/salt now appears in Contributed Repositories
- [ ] cal.com now appears in Contributed Repositories
- [ ] All repos with open PRs (marimo, hono, devopness, mindsdb, superduper, etc.) appear
- [ ] Stars Earned card is gone
- [ ] PR count reflects actual open + merged PRs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fetch all open and merged PRs by splitting the GitHub search (100 each) so PR counts and contributed repos are complete. Removed the “Stars Earned” card and updated the stats grid to 4 columns.

- **Bug Fixes**
  - Split PR search into merged + open (100 each) to avoid the 20-result cap.
  - Combine results so contributed repos and PR count include older PRs (e.g., saltstack/salt, cal.com).

- **Refactors**
  - Removed “Stars Earned” stat and totalStars from types.
  - Updated stats grid to 4 columns for the remaining cards.

<sup>Written for commit 3c895e965ab6c43662371ad7a17a0aea44ee4299. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

