### PR TITLE
perf: reduce animation overhead and main-thread work

### DIFF
--- a/src/app/(marketing)/about/about-content.tsx
+++ b/src/app/(marketing)/about/about-content.tsx
@@ -339,49 +339,36 @@ export function AboutContent() {
 
 function SkillCategory({ title, skills: skillList }: { title: string; skills: string[] }) {
   return (
-    <m.div
-      whileHover={{ scale: 1.02 }}
-      transition={{ type: "spring", stiffness: 300 }}
-    >
-      <Card className="h-full min-h-[200px] hover:border-primary/50 transition-colors flex flex-col">
-        <CardHeader className="pb-3">
-          <CardTitle className="text-lg">{title}</CardTitle>
-        </CardHeader>
-        <CardContent className="flex-1">
-          <div className="flex flex-wrap gap-2">
-            {skillList.map((skill, index) => {
-              const IconComponent = skillIcons[skill];
-              return (
-                <m.div
-                  key={skill}
-                  initial={{ opacity: 0, scale: 0.8 }}
-                  whileInView={{ opacity: 1, scale: 1 }}
-                  viewport={{ once: true }}
-                  transition={{ delay: index * 0.03 }}
-                  whileHover={{ scale: 1.1 }}
-                >
-                  <Link
-                    href={`https://www.google.com/search?q=${encodeURIComponent(skill)}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-block"
-                  >
-                    <Badge variant="secondary" className="flex items-center gap-1.5 cursor-pointer hover:bg-primary/20 transition-colors">
-                      {IconComponent && (
-                        <IconComponent 
-                          className="w-3.5 h-3.5 text-current" 
-                          strokeWidth={2}
-                        />
-                      )}
-                      {skill}
-                    </Badge>
-                  </Link>
-                </m.div>
-              );
-            })}
-          </div>
-        </CardContent>
-      </Card>
-    </m.div>
+    <Card className="h-full min-h-[200px] hover:border-primary/50 transition-colors flex flex-col">
+      <CardHeader className="pb-3">
+        <CardTitle className="text-lg">{title}</CardTitle>
+      </CardHeader>
+      <CardContent className="flex-1">
+        <div className="flex flex-wrap gap-2">
+          {skillList.map((skill) => {
+            const IconComponent = skillIcons[skill];
+            return (
+              <Link
+                key={skill}
+                href={`https://www.google.com/search?q=${encodeURIComponent(skill)}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-block"
+              >
+                <Badge variant="secondary" className="flex items-center gap-1.5 cursor-pointer hover:bg-primary/20 hover:scale-105 transition-all">
+                  {IconComponent && (
+                    <IconComponent
+                      className="w-3.5 h-3.5 text-current"
+                      strokeWidth={2}
+                    />
+                  )}
+                  {skill}
+                </Badge>
+              </Link>
+            );
+          })}
+        </div>
+      </CardContent>
+    </Card>
   );
 }

--- a/src/app/(marketing)/experience/experience-content.tsx
+++ b/src/app/(marketing)/experience/experience-content.tsx
@@ -120,13 +120,7 @@ export function ExperienceContent() {
                   whileInView={{ scale: 1 }}
                   viewport={{ once: true }}
                   transition={{ delay: 0.3 + index * 0.1, type: "spring", stiffness: 500 }}
-                >
-                  <m.div
-                    className="absolute inset-0 rounded-full bg-primary"
-                    animate={{ scale: [1, 1.5, 1], opacity: [1, 0, 1] }}
-                    transition={{ duration: 2, repeat: Infinity, delay: index * 0.5 }}
-                  />
-                </m.div>
+                />
 
                 <ExperienceCard experience={exp} />
               </m.div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -46,6 +46,9 @@
   --radius-2xl: calc(var(--radius) + 8px);
   --radius-3xl: calc(var(--radius) + 12px);
   --radius-4xl: calc(var(--radius) + 16px);
+  --animate-orb-drift-1: orb-drift-1 8s ease-in-out infinite;
+  --animate-orb-drift-2: orb-drift-2 10s ease-in-out infinite;
+  --animate-orb-pulse: orb-pulse 6s ease-in-out infinite;
 }
 
 :root {
@@ -134,5 +137,31 @@
   html, body {
     scroll-padding-top: 0;
     scroll-margin-top: 0;
+  }
+}
+
+/* Background orb animations — run on compositor thread */
+@keyframes orb-drift-1 {
+  0%, 100% { transform: translate(0, 0); }
+  50% { transform: translate(30px, -20px); }
+}
+
+@keyframes orb-drift-2 {
+  0%, 100% { transform: translate(0, 0); }
+  50% { transform: translate(-30px, 20px); }
+}
+
+@keyframes orb-pulse {
+  0%, 100% { transform: translate(-50%, -50%) scale(1); }
+  50% { transform: translate(-50%, -50%) scale(1.1); }
+}
+
+/* Accessibility: disable animations for users who prefer reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
   }
 }

--- a/src/app/open-source/open-source-content.tsx
+++ b/src/app/open-source/open-source-content.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { motion, MotionConfig } from "motion/react";
+import * as m from "motion/react-m";
+import { MotionConfig } from "motion/react";
 import { StatsOverview } from "@/components/open-source/stats-overview";
 import { RepoGrid } from "@/components/open-source/repo-grid";
 import { PrTracker } from "@/components/open-source/pr-tracker";
@@ -18,21 +19,21 @@ export function OpenSourceContent({ data }: OpenSourceContentProps) {
       <div className="min-h-screen py-24">
         <div className="container mx-auto px-4 max-w-6xl space-y-16">
           {/* Header */}
-          <motion.div
+          <m.div
             className="text-center space-y-4"
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.5 }}
           >
-            <motion.h1
+            <m.h1
               className="font-heading text-4xl sm:text-5xl font-bold"
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.5, delay: 0.1 }}
             >
               Open Source
-            </motion.h1>
-            <motion.p
+            </m.h1>
+            <m.p
               className="text-muted-foreground max-w-2xl mx-auto text-lg"
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
@@ -40,8 +41,8 @@ export function OpenSourceContent({ data }: OpenSourceContentProps) {
             >
               Contributions, projects, and activity across the open source
               ecosystem
-            </motion.p>
-          </motion.div>
+            </m.p>
+          </m.div>
 
           {/* Stats Overview */}
           <section aria-label="GitHub statistics">
@@ -50,7 +51,7 @@ export function OpenSourceContent({ data }: OpenSourceContentProps) {
 
           {/* Activity Dashboard — right after stats */}
           <section aria-label="Contribution activity dashboard">
-            <motion.h2
+            <m.h2
               className="font-heading text-2xl sm:text-3xl font-bold mb-8"
               initial={{ opacity: 0, y: 20 }}
               whileInView={{ opacity: 1, y: 0 }}
@@ -58,7 +59,7 @@ export function OpenSourceContent({ data }: OpenSourceContentProps) {
               transition={{ duration: 0.5 }}
             >
               Activity
-            </motion.h2>
+            </m.h2>
             <GlassmorphismContainer>
               <ActivityTabs
                 contributionDays={data.contributionDays}
@@ -71,7 +72,7 @@ export function OpenSourceContent({ data }: OpenSourceContentProps) {
           {/* Forked Repositories — external contributions */}
           {data.repos.length > 0 && (
             <section aria-label="Contributed repositories">
-              <motion.h2
+              <m.h2
                 className="font-heading text-2xl sm:text-3xl font-bold mb-8"
                 initial={{ opacity: 0, y: 20 }}
                 whileInView={{ opacity: 1, y: 0 }}
@@ -79,7 +80,7 @@ export function OpenSourceContent({ data }: OpenSourceContentProps) {
                 transition={{ duration: 0.5 }}
               >
                 Contributed Repositories
-              </motion.h2>
+              </m.h2>
               <RepoGrid repos={data.repos} />
             </section>
           )}
@@ -87,7 +88,7 @@ export function OpenSourceContent({ data }: OpenSourceContentProps) {
           {/* Pull Requests */}
           {data.pullRequests.length > 0 && (
             <section aria-label="External pull requests">
-              <motion.h2
+              <m.h2
                 className="font-heading text-2xl sm:text-3xl font-bold mb-8"
                 initial={{ opacity: 0, y: 20 }}
                 whileInView={{ opacity: 1, y: 0 }}
@@ -95,7 +96,7 @@ export function OpenSourceContent({ data }: OpenSourceContentProps) {
                 transition={{ duration: 0.5 }}
               >
                 Pull Requests
-              </motion.h2>
+              </m.h2>
               <PrTracker pullRequests={data.pullRequests} />
             </section>
           )}

--- a/src/components/home/hero.tsx
+++ b/src/components/home/hero.tsx
@@ -16,33 +16,9 @@ export function Hero() {
       {/* Animated background */}
       <div className="absolute inset-0 -z-10">
         <div className="absolute inset-0 bg-gradient-to-br from-background via-background to-primary/5" />
-        <m.div
-          className="absolute top-20 left-10 w-72 h-72 bg-primary/10 rounded-full blur-3xl"
-          animate={isInView ? { x: [0, 30, 0], y: [0, -20, 0] } : { x: 0, y: 0 }}
-          transition={{
-            duration: 8,
-            repeat: isInView ? Infinity : 0,
-            ease: "easeInOut",
-          }}
-        />
-        <m.div
-          className="absolute bottom-20 right-10 w-96 h-96 bg-primary/5 rounded-full blur-3xl"
-          animate={isInView ? { x: [0, -40, 0], y: [0, 30, 0] } : { x: 0, y: 0 }}
-          transition={{
-            duration: 10,
-            repeat: isInView ? Infinity : 0,
-            ease: "easeInOut",
-          }}
-        />
-        <m.div
-          className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[500px] h-[500px] bg-primary/5 rounded-full blur-3xl"
-          animate={isInView ? { scale: [1, 1.1, 1] } : { scale: 1 }}
-          transition={{
-            duration: 6,
-            repeat: isInView ? Infinity : 0,
-            ease: "easeInOut",
-          }}
-        />
+        <div className="absolute top-20 left-10 w-72 h-72 bg-primary/10 rounded-full blur-3xl will-change-transform animate-orb-drift-1" />
+        <div className="absolute bottom-20 right-10 w-96 h-96 bg-primary/5 rounded-full blur-3xl will-change-transform animate-orb-drift-2" />
+        <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[500px] h-[500px] bg-primary/5 rounded-full blur-3xl will-change-transform animate-orb-pulse" />
         
         {/* Animated grid pattern */}
         <div className="absolute inset-0 bg-[linear-gradient(rgba(255,255,255,0.02)_1px,transparent_1px),linear-gradient(90deg,rgba(255,255,255,0.02)_1px,transparent_1px)] bg-[size:50px_50px] [mask-image:radial-gradient(ellipse_at_center,black_20%,transparent_70%)]" />

--- a/src/components/open-source/activity-tabs.tsx
+++ b/src/components/open-source/activity-tabs.tsx
@@ -2,7 +2,8 @@
 
 import { useState } from "react";
 import dynamic from "next/dynamic";
-import { motion, AnimatePresence } from "motion/react";
+import * as m from "motion/react-m";
+import { AnimatePresence } from "motion/react";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { CommitTimeline } from "./commit-timeline";
 import type {
@@ -61,7 +62,7 @@ export function ActivityTabs({
       </Tabs>
 
       <AnimatePresence mode="wait">
-        <motion.div
+        <m.div
           key={activeTab}
           initial={{ opacity: 0, y: 10 }}
           animate={{ opacity: 1, y: 0 }}
@@ -78,7 +79,7 @@ export function ActivityTabs({
           {activeTab === "timeline" && (
             <CommitTimeline commits={recentCommits} />
           )}
-        </motion.div>
+        </m.div>
       </AnimatePresence>
     </div>
   );

--- a/src/components/open-source/commit-timeline.tsx
+++ b/src/components/open-source/commit-timeline.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { motion } from "motion/react";
+import * as m from "motion/react-m";
 import { GitCommit } from "lucide-react";
 import type { CommitEvent } from "@/lib/data/github-types";
 
@@ -38,7 +38,7 @@ export function CommitTimeline({ commits }: CommitTimelineProps) {
   }
 
   return (
-    <motion.div
+    <m.div
       className="relative space-y-0"
       initial="hidden"
       animate="visible"
@@ -50,7 +50,7 @@ export function CommitTimeline({ commits }: CommitTimelineProps) {
       <div className="absolute left-[15px] top-3 bottom-3 w-px bg-border" />
 
       {commits.map((commit) => (
-        <motion.div
+        <m.div
           key={commit.url}
           variants={{
             hidden: { opacity: 0, x: -10 },
@@ -77,8 +77,8 @@ export function CommitTimeline({ commits }: CommitTimelineProps) {
               <span>{timeAgo(commit.committedDate)}</span>
             </div>
           </div>
-        </motion.div>
+        </m.div>
       ))}
-    </motion.div>
+    </m.div>
   );
 }

--- a/src/components/open-source/error-fallback.tsx
+++ b/src/components/open-source/error-fallback.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { motion } from "motion/react";
+import * as m from "motion/react-m";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { AlertCircle } from "lucide-react";
@@ -15,7 +15,7 @@ export function ErrorFallback({
   onRetry,
 }: ErrorFallbackProps) {
   return (
-    <motion.div
+    <m.div
       initial={{ opacity: 0, y: 10 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.4 }}
@@ -31,6 +31,6 @@ export function ErrorFallback({
           )}
         </CardContent>
       </Card>
-    </motion.div>
+    </m.div>
   );
 }

--- a/src/components/open-source/glassmorphism-container.tsx
+++ b/src/components/open-source/glassmorphism-container.tsx
@@ -1,6 +1,3 @@
-"use client";
-
-import { motion } from "motion/react";
 import { cn } from "@/lib/utils";
 import { type ReactNode } from "react";
 
@@ -15,17 +12,9 @@ export function GlassmorphismContainer({
 }: GlassmorphismContainerProps) {
   return (
     <div className={cn("relative overflow-hidden rounded-2xl", className)}>
-      {/* Animated background orbs */}
-      <motion.div
-        className="absolute -top-20 -left-20 h-64 w-64 rounded-full bg-emerald-500/20 blur-3xl"
-        animate={{ x: [0, 30, 0], y: [0, 20, 0] }}
-        transition={{ repeat: Infinity, duration: 8, ease: "easeInOut" }}
-      />
-      <motion.div
-        className="absolute -bottom-20 -right-20 h-64 w-64 rounded-full bg-purple-500/20 blur-3xl"
-        animate={{ x: [0, -30, 0], y: [0, -20, 0] }}
-        transition={{ repeat: Infinity, duration: 10, ease: "easeInOut" }}
-      />
+      {/* Background orbs — CSS-animated for compositor-thread performance */}
+      <div className="absolute -top-20 -left-20 h-64 w-64 rounded-full bg-emerald-500/20 blur-3xl will-change-transform animate-orb-drift-1" />
+      <div className="absolute -bottom-20 -right-20 h-64 w-64 rounded-full bg-purple-500/20 blur-3xl will-change-transform animate-orb-drift-2" />
       {/* Glass container */}
       <div className="relative rounded-xl border border-white/10 bg-card/50 backdrop-blur-xl p-6 shadow-xl">
         {children}

--- a/src/components/open-source/pr-tracker.tsx
+++ b/src/components/open-source/pr-tracker.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { motion } from "motion/react";
+import * as m from "motion/react-m";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
@@ -43,7 +43,7 @@ export function PrTracker({ pullRequests }: PrTrackerProps) {
   }
 
   return (
-    <motion.div
+    <m.div
       className="space-y-3"
       initial="hidden"
       whileInView="visible"
@@ -55,7 +55,7 @@ export function PrTracker({ pullRequests }: PrTrackerProps) {
       {pullRequests.map((pr) => {
         const config = statusConfig[pr.state];
         return (
-          <motion.div
+          <m.div
             key={pr.url}
             variants={{
               hidden: { opacity: 0, x: -20 },
@@ -96,7 +96,7 @@ export function PrTracker({ pullRequests }: PrTrackerProps) {
                   )}
                 >
                   {pr.state === "open" && (
-                    <motion.span
+                    <m.span
                       className="h-1.5 w-1.5 rounded-full bg-current"
                       animate={{ opacity: [1, 0.4, 1] }}
                       transition={{ repeat: Infinity, duration: 2 }}
@@ -106,9 +106,9 @@ export function PrTracker({ pullRequests }: PrTrackerProps) {
                 </Badge>
               </Card>
             </a>
-          </motion.div>
+          </m.div>
         );
       })}
-    </motion.div>
+    </m.div>
   );
 }

--- a/src/components/open-source/repo-card.tsx
+++ b/src/components/open-source/repo-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { motion } from "motion/react";
+import * as m from "motion/react-m";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Star, GitFork, ExternalLink } from "lucide-react";
 import type { GitHubRepo } from "@/lib/data/github-types";
@@ -11,7 +11,7 @@ interface RepoCardProps {
 
 export function RepoCard({ repo }: RepoCardProps) {
   return (
-    <motion.div
+    <m.div
       whileHover={{ y: -5, transition: { type: "spring", stiffness: 300, damping: 20 } }}
       className="h-full"
     >
@@ -58,6 +58,6 @@ export function RepoCard({ repo }: RepoCardProps) {
           </CardContent>
         </Card>
       </a>
-    </motion.div>
+    </m.div>
   );
 }

--- a/src/components/open-source/repo-grid.tsx
+++ b/src/components/open-source/repo-grid.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { motion } from "motion/react";
+import * as m from "motion/react-m";
 import { RepoCard } from "./repo-card";
 import type { GitHubRepo } from "@/lib/data/github-types";
 
@@ -18,7 +18,7 @@ export function RepoGrid({ repos }: RepoGridProps) {
   }
 
   return (
-    <motion.div
+    <m.div
       className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"
       initial="hidden"
       whileInView="visible"
@@ -28,7 +28,7 @@ export function RepoGrid({ repos }: RepoGridProps) {
       }}
     >
       {repos.map((repo) => (
-        <motion.div
+        <m.div
           key={repo.name}
           variants={{
             hidden: { opacity: 0, y: 30, scale: 0.95 },
@@ -38,8 +38,8 @@ export function RepoGrid({ repos }: RepoGridProps) {
           className="h-full"
         >
           <RepoCard repo={repo} />
-        </motion.div>
+        </m.div>
       ))}
-    </motion.div>
+    </m.div>
   );
 }

--- a/src/components/open-source/stats-overview.tsx
+++ b/src/components/open-source/stats-overview.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { motion } from "motion/react";
+import * as m from "motion/react-m";
 import { Card, CardContent } from "@/components/ui/card";
 import { AnimatedCounter } from "@/components/ui/animated-counter";
 import {
@@ -40,7 +40,7 @@ const statItems = [
 
 export function StatsOverview({ stats }: StatsOverviewProps) {
   return (
-    <motion.div
+    <m.div
       className="grid grid-cols-2 sm:grid-cols-4 gap-4"
       initial="hidden"
       whileInView="visible"
@@ -52,7 +52,7 @@ export function StatsOverview({ stats }: StatsOverviewProps) {
       {statItems.map((item) => {
         const Icon = item.icon;
         return (
-          <motion.div
+          <m.div
             key={item.key}
             variants={{
               hidden: { opacity: 0, y: 20, scale: 0.95 },
@@ -70,9 +70,9 @@ export function StatsOverview({ stats }: StatsOverviewProps) {
                 <p className="text-xs text-muted-foreground">{item.label}</p>
               </CardContent>
             </Card>
-          </motion.div>
+          </m.div>
         );
       })}
-    </motion.div>
+    </m.div>
   );
 }


### PR DESCRIPTION
## Summary

- **Fix LazyMotion bypass** in 9 open-source components — replaced `import { motion }` with `import * as m from "motion/react-m"` to eliminate redundant full motion bundle imports (~30KB)
- **Replace 5 infinite JS-animated blur orbs** (hero: 3, glassmorphism: 2) with CSS `@keyframes` — runs on compositor thread with zero React reconciliation
- **Remove 6 infinite-pulsing timeline dots** on experience page — the entrance animation remains, the infinite pulse is gone
- **Eliminate 60+ individual IntersectionObservers** on About skills page — replaced per-badge `whileInView` + `whileHover` with container-level `StaggerItem` + CSS `hover:scale-105`
- **Add `prefers-reduced-motion`** media query for accessibility
- **GlassmorphismContainer** no longer needs `"use client"` (removed motion dependency entirely)

13 files changed, net -23 lines of code.

## Test plan

- [ ] Verify Vercel preview deploys successfully
- [ ] Navigate all sections — should feel snappier on scroll
- [ ] Check open-source page loads and animates correctly
- [ ] Check hero orbs still drift smoothly (now via CSS)
- [ ] Experience timeline dots appear on scroll (no infinite pulse)
- [ ] About skills badges still hover-highlight
- [ ] Test `prefers-reduced-motion: reduce` in DevTools — animations disabled

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts animation overhead and main-thread work by moving infinite animations to CSS and fixing LazyMotion usage. Pages feel smoother, with less JS loaded and fewer React updates on scroll.

- **Refactors**
  - Switch open-source components to motion/react-m (LazyMotion) to avoid full motion bundle (~30KB saved).
  - Replace 5 JS blur orbs with CSS keyframes (hero: 3, glassmorphism: 2) for compositor-thread animations.
  - Remove 6 infinite pulsing dots from the experience timeline; keep entrance animation.
  - Drop per-badge whileInView/whileHover on About skills; use container-level animation and CSS hover:scale-105, removing 60+ IntersectionObservers.
  - Remove "use client" from GlassmorphismContainer (no motion dependency).

- **New Features**
  - Add prefers-reduced-motion support to disable animations and transitions for users who request it.

<sup>Written for commit 23f65fbcb0232911e1cf7f3eecccbd7f852a555b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

