### PR TITLE
feat: emerald brand dot on Ahmad./Ahmad Yasser.

### DIFF
--- a/src/components/home/hero.tsx
+++ b/src/components/home/hero.tsx
@@ -77,13 +77,20 @@ export function Hero() {
             >
               Hi, I&apos;m{" "}
             </m.span>
-            <m.span 
+            <m.span
               className="text-transparent bg-clip-text bg-gradient-to-r from-primary to-primary/60 inline-block"
               initial={{ opacity: 0, x: -20 }}
               animate={{ opacity: 1, x: 0 }}
               transition={{ delay: 0.3, duration: 0.6 }}
             >
               Ahmad Yasser
+            </m.span>
+            <m.span
+              className="text-emerald-500"
+              animate={{ opacity: [1, 0.5, 1] }}
+              transition={{ duration: 2, repeat: Infinity }}
+            >
+              .
             </m.span>
           </m.h1>
 

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -90,8 +90,8 @@ export function Footer() {
               className="font-heading text-lg font-bold tracking-tight"
             >
               <span className="text-foreground">Ahmad Yasser</span>
-              <m.span 
-                className="text-primary"
+              <m.span
+                className="text-emerald-500"
                 animate={{ opacity: [1, 0.5, 1] }}
                 transition={{ duration: 2, repeat: Infinity }}
               >

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -64,8 +64,8 @@ export function Navbar() {
           >
             Ahmad
           </m.span>
-          <m.span 
-            className="text-primary"
+          <m.span
+            className="text-emerald-500"
             animate={{ opacity: [1, 0.5, 1] }}
             transition={{ duration: 2, repeat: Infinity }}
           >


### PR DESCRIPTION
## Summary

- Navbar "Ahmad." dot → `text-emerald-500` (matching favicon accent)
- Footer "Ahmad Yasser." dot → `text-emerald-500`
- Hero adds emerald pulsing dot after "Ahmad Yasser"

Unifies the emerald #10b981 brand accent from the favicon across all visible name instances.

## Test plan

- [ ] Verify Vercel preview — navbar, footer, hero dots are emerald

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unified the animated dot accent to emerald (#10b981) to match the favicon and keep the Ahmad/Ahmad Yasser name styling consistent. Added a pulsing emerald dot after “Ahmad Yasser” in the hero.

- New Features
  - Navbar: “Ahmad.” dot uses text-emerald-500
  - Footer: “Ahmad Yasser.” dot uses text-emerald-500
  - Hero: new pulsing emerald dot after “Ahmad Yasser”

<sup>Written for commit a83e0621a2f9d12c136515f83270e04552a77302. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

