### PR TITLE
fix: remove double translate on center hero orb

### DIFF
--- a/src/components/home/hero.tsx
+++ b/src/components/home/hero.tsx
@@ -18,7 +18,7 @@ export function Hero() {
         <div className="absolute inset-0 bg-gradient-to-br from-background via-background to-primary/5" />
         <div className="absolute top-20 left-10 w-72 h-72 bg-primary/10 rounded-full blur-3xl will-change-transform animate-orb-drift-1" />
         <div className="absolute bottom-20 right-10 w-96 h-96 bg-primary/5 rounded-full blur-3xl will-change-transform animate-orb-drift-2" />
-        <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[500px] h-[500px] bg-primary/5 rounded-full blur-3xl will-change-transform animate-orb-pulse" />
+        <div className="absolute top-1/2 left-1/2 w-[500px] h-[500px] bg-primary/5 rounded-full blur-3xl will-change-transform animate-orb-pulse" />
         
         {/* Animated grid pattern */}
         <div className="absolute inset-0 bg-[linear-gradient(rgba(255,255,255,0.02)_1px,transparent_1px),linear-gradient(90deg,rgba(255,255,255,0.02)_1px,transparent_1px)] bg-[size:50px_50px] [mask-image:radial-gradient(ellipse_at_center,black_20%,transparent_70%)]" />


### PR DESCRIPTION
## Summary

- Remove `-translate-x-1/2 -translate-y-1/2` from the center hero orb div

In Tailwind v4, these utilities generate the individual CSS `translate` property, which is **additive** with the `transform` property used in the `@keyframes orb-pulse`. The orb was getting double-translated to -100%/-100% instead of centered at -50%/-50%.

The keyframe already includes `translate(-50%, -50%)` so the Tailwind utilities were redundant and causing the bug.

Found by cubic review on PR #11.

## Test plan

- [ ] Verify center orb is properly centered on hero section (not offset)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix center hero orb being offset by double translation. Removed -translate-x-1/2 and -translate-y-1/2 since the orb-pulse keyframe already applies translate(-50%,-50%) and Tailwind v4’s translate adds to transform.

<sup>Written for commit 86b453207edbf0a1afe636f2cd39d185f6ad8938. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

