### PR TITLE
fix: address Cubic bot review issues from PR #16

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A portfolio site built with Next.js, TypeScript, Tailwind CSS, and Framer Motion
 
 ## Available scripts
 
-- `npm run dev` - start local development server (Webpack mode).
+- `npm run dev` - start local development server (Turbopack).
 - `npm run build` - create production build.
 - `npm run start` - start production server from build output.
 - `npm run lint` - run ESLint checks.

--- a/src/components/home/hero.tsx
+++ b/src/components/home/hero.tsx
@@ -11,9 +11,9 @@ export function Hero() {
       {/* Background — radial gradients (zero-cost vs blur-3xl) */}
       <div className="absolute inset-0 -z-10">
         <div className="absolute inset-0 bg-gradient-to-br from-background via-background to-primary/5" />
-        <div className="absolute top-20 left-10 w-72 h-72 [background:radial-gradient(circle,oklch(0.72_0.19_155/0.10)_0%,transparent_70%)] will-change-transform animate-orb-drift-1" />
-        <div className="absolute bottom-20 right-10 w-96 h-96 [background:radial-gradient(circle,oklch(0.72_0.19_155/0.05)_0%,transparent_70%)] will-change-transform animate-orb-drift-2" />
-        <div className="absolute top-1/2 left-1/2 w-[500px] h-[500px] [background:radial-gradient(circle,oklch(0.72_0.19_155/0.05)_0%,transparent_70%)] will-change-transform animate-orb-pulse" />
+        <div className="absolute top-20 left-10 w-72 h-72 [background:radial-gradient(circle,oklch(from_var(--color-emerald-500)_l_c_h/0.10)_0%,transparent_70%)] will-change-transform animate-orb-drift-1" />
+        <div className="absolute bottom-20 right-10 w-96 h-96 [background:radial-gradient(circle,oklch(from_var(--color-emerald-500)_l_c_h/0.05)_0%,transparent_70%)] will-change-transform animate-orb-drift-2" />
+        <div className="absolute top-1/2 left-1/2 w-[500px] h-[500px] [background:radial-gradient(circle,oklch(from_var(--color-emerald-500)_l_c_h/0.05)_0%,transparent_70%)] will-change-transform animate-orb-pulse" />
 
         {/* Grid pattern */}
         <div className="absolute inset-0 bg-[linear-gradient(rgba(255,255,255,0.02)_1px,transparent_1px),linear-gradient(90deg,rgba(255,255,255,0.02)_1px,transparent_1px)] bg-[size:50px_50px] [mask-image:radial-gradient(ellipse_at_center,black_20%,transparent_70%)]" />

--- a/src/components/open-source/glassmorphism-container.tsx
+++ b/src/components/open-source/glassmorphism-container.tsx
@@ -13,7 +13,7 @@ export function GlassmorphismContainer({
   return (
     <div className={cn("relative overflow-hidden rounded-2xl", className)}>
       {/* Background orbs — radial gradients (zero-cost vs blur-3xl) */}
-      <div className="absolute -top-20 -left-20 h-64 w-64 [background:radial-gradient(circle,oklch(0.72_0.19_155/0.20)_0%,transparent_70%)] will-change-transform animate-orb-drift-1" />
+      <div className="absolute -top-20 -left-20 h-64 w-64 [background:radial-gradient(circle,oklch(from_var(--color-emerald-500)_l_c_h/0.20)_0%,transparent_70%)] will-change-transform animate-orb-drift-1" />
       <div className="absolute -bottom-20 -right-20 h-64 w-64 [background:radial-gradient(circle,oklch(0.7_0.15_300/0.20)_0%,transparent_70%)] will-change-transform animate-orb-drift-2" />
       {/* Glass container */}
       <div className="relative rounded-xl border border-white/10 bg-card/50 backdrop-blur-xl p-6 shadow-xl">

--- a/src/lib/data/projects.ts
+++ b/src/lib/data/projects.ts
@@ -126,7 +126,7 @@ export const projects: Project[] = [
       "Led authorship of 'Fostering Positive Connections Through Interactive Messages: HAPPI', a paper accepted at the CHI 2025 Student Design Competition. Designed and prototyped an interactive device that promotes emotional wellness through community-driven messaging.",
     technologies: ["User Research", "Prototyping", "Academic Writing", "Thematic Analysis"],
     category: "research",
-    githubUrl: "https://doi.org/10.1145/3706599.3720296",
+    liveUrl: "https://doi.org/10.1145/3706599.3720296",
     featured: false,
   },
   {


### PR DESCRIPTION
## Summary

- **P2**: Move HAPPI DOI link from `githubUrl` to `liveUrl` — prevents GitHub icon rendering for an ACM Digital Library URL
- **P2**: Replace hardcoded `oklch(0.72_0.19_155/...)` orb colors with `oklch(from var(--color-emerald-500) l c h / alpha)` using CSS Relative Color Syntax for theme consistency
- **P3**: Update README dev script description from "Webpack mode" to "Turbopack"

## Test plan

- [x] Lint passes (0 errors)
- [x] TypeScript typecheck passes
- [ ] Verify HAPPI project card shows external link icon, not GitHub icon
- [ ] Verify hero orbs still render emerald gradients in both light/dark mode

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the HAPPI DOI from githubUrl to liveUrl so the project card shows the external link icon instead of the GitHub icon. Replaced hardcoded orb gradient colors with CSS Relative Color Syntax using var(--color-emerald-500), and updated the README to say the dev server uses Turbopack.

<sup>Written for commit 78d43f1dd56682e9fd54077517012538c77ba21e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

